### PR TITLE
Add correct stack trace on AttributeError (#403)

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -14,6 +14,7 @@ import os
 import logging
 import select
 import socket
+import sys
 import time
 import warnings
 import errno
@@ -240,7 +241,7 @@ class BlockingConnection(base_connection.BaseConnection):
             if self._handle_read():
                 self._socket_timeouts = 0
         except AttributeError:
-            raise exceptions.ConnectionClosed()
+            raise exceptions.ConnectionClosed(), None, sys.exc_info()[2]
         except socket.timeout:
             self._handle_timeout()
         self._flush_outbound()


### PR DESCRIPTION
When an `AttributeError` occurs in a callback, it is swallowed by the surrounding `try` block and a `ConnectionClosed` is raised. This hides the underlying exception, making debugging more difficult. In this case, we add the stack trace from the original exception to show the true source of the error. This fixes issue #403.
